### PR TITLE
coala.sh: Change the shell interpreter

### DIFF
--- a/coala.sh
+++ b/coala.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$1" = "install" ]]; then
     python3 -m venv coala-venv


### PR DESCRIPTION
This changes the shell interpreter for this script in order to
explicitly use bash. `/bin/sh` points to `/bin/bash` on some
systems but not on others. `/bin/sh` doesn't know about `[[`,
that's why the conditionals would fail and the script would
always print the help message on these systems.

Fixes https://github.com/Kagamihime/VIlain/issues/17