### PR TITLE
.gitignore: Add the build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.obj
 *.elf
 
+# Build directory
+build/
+
 # Linker output
 *.ilk
 *.map


### PR DESCRIPTION
This adds the build directory in the list of the files ignored by
git so that git doesn't list it as untracked.

Closes https://github.com/Kagamihime/VIlain/issues/50